### PR TITLE
Use eventbus.Error instead of common error

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,12 +51,12 @@ func NewClient() (*v1.Client, error) {
 func NewClientWithApiUrl(apiUrl string) (*v1.Client, error) {
 	c, err := client.NewClient(apiUrl, client.WithUserAgent(UserAgent))
 	if err != nil {
-		return nil, err
+		return nil, NewError("NewClientWithApiUrl", err)
 	}
 
 	v1Client, err := v1.NewClient(c.ServerURL(), DummySecuritySource{Token: "eventbus-client"}, v1.WithClient(c.NewHttpRequestDoer()))
 	if err != nil {
-		return nil, fmt.Errorf("create client: %w", err)
+		return nil, NewError("NewClientWithApiUrl", err)
 	}
 
 	return v1Client, nil

--- a/error.go
+++ b/error.go
@@ -1,0 +1,43 @@
+// Copyright 2025- The sacloud/eventbus-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventbus
+
+type Error struct {
+	msg string
+	err error
+}
+
+func (e *Error) Error() string {
+	if e.msg != "" {
+		if e.err != nil {
+			return "eventbus: " + e.msg + ": " + e.err.Error()
+		} else {
+			return "eventbus: " + e.msg
+		}
+	} else {
+		return "eventbus: " + e.err.Error()
+	}
+}
+
+func (e *Error) Unwrap() error {
+	return e.err
+}
+
+func NewError(msg string, err error) *Error {
+	if err == nil {
+		return &Error{msg: msg}
+	}
+	return &Error{msg: msg, err: err}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,55 @@
+package eventbus
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestError_Error(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	tests := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{
+			name: "with msg and err",
+			err:  &Error{msg: "something failed", err: baseErr},
+			want: "eventbus: something failed: base error",
+		},
+		{
+			name: "with msg only",
+			err:  &Error{msg: "only msg"},
+			want: "eventbus: only msg",
+		},
+		{
+			name: "with err only",
+			err:  &Error{err: baseErr},
+			want: "eventbus: base error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			if got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewError(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	err := NewError("msg", baseErr)
+	if err.msg != "msg" || err.err != baseErr {
+		t.Errorf("NewError() did not set fields correctly")
+	}
+
+	err2 := NewError("msg only", nil)
+	if err2.msg != "msg only" || err2.err != nil {
+		t.Errorf("NewError() with nil err did not set fields correctly")
+	}
+}

--- a/process_configurations.go
+++ b/process_configurations.go
@@ -44,42 +44,42 @@ func NewProcessConfigurationOp(client *v1.Client) ProcessConfigurationAPI {
 func (op *processConfigurationOp) List(ctx context.Context) ([]v1.ProcessConfiguration, error) {
 	res, err := op.client.GetProcessConfigurations(ctx)
 	if err != nil {
-		return nil, err
+		return nil, NewError("List", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.GetProcessConfigurationsOK:
 		return p.ProcessConfigurations, nil
 	case *v1.GetProcessConfigurationsUnauthorized:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("List", errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationsBadRequest:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("List", errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationsInternalServerError:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("List", errors.New(p.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("List", errors.New("unknown error"))
 	}
 }
 
 func (op *processConfigurationOp) Read(ctx context.Context, id string) (*v1.ProcessConfiguration, error) {
 	res, err := op.client.GetProcessConfigurationById(ctx, v1.GetProcessConfigurationByIdParams{ID: id})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Read", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.GetProcessConfigurationByIdOK:
 		return &p.ProcessConfiguration, nil
 	case *v1.GetProcessConfigurationByIdUnauthorized:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Read", errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationByIdBadRequest:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Read", errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationByIdNotFound:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Read", errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationByIdInternalServerError:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Read", errors.New(p.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Read", errors.New("unknown error"))
 	}
 }
 
@@ -88,20 +88,20 @@ func (op *processConfigurationOp) Create(ctx context.Context, request v1.Process
 		ProcessConfiguration: request,
 	})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Create", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.CreateProcessConfigurationOK:
 		return &p.ProcessConfiguration, nil
 	case *v1.CreateProcessConfigurationBadRequest:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Create", errors.New(p.Message.Value))
 	case *v1.CreateProcessConfigurationUnauthorized:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Create", errors.New(p.Message.Value))
 	case *v1.CreateProcessConfigurationInternalServerError:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Create", errors.New(p.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Create", errors.New("unknown error"))
 	}
 }
 
@@ -110,20 +110,20 @@ func (op *processConfigurationOp) Update(ctx context.Context, id string, request
 		ProcessConfiguration: request,
 	}, v1.ConfigureProcessConfigurationParams{ID: id})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Update", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.ConfigureProcessConfigurationOK:
 		return &p.ProcessConfiguration, nil
 	case *v1.ConfigureProcessConfigurationBadRequest:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Update", errors.New(p.Message.Value))
 	case *v1.ConfigureProcessConfigurationNotFound:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Update", errors.New(p.Message.Value))
 	case *v1.ConfigureProcessConfigurationInternalServerError:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Update", errors.New(p.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Update", errors.New("unknown error"))
 	}
 }
 
@@ -132,42 +132,42 @@ func (op *processConfigurationOp) UpdateSecret(ctx context.Context, id string, s
 		Secret: secret,
 	}, v1.ConfigureProcessConfigurationSecretParams{ID: id})
 	if err != nil {
-		return err
+		return NewError("UpdateSecret", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.ConfigureProcessConfigurationSecretOK:
 		return nil
 	case *v1.ConfigureProcessConfigurationSecretBadRequest:
-		return errors.New(p.Message.Value)
+		return NewError("UpdateSecret", errors.New(p.Message.Value))
 	case *v1.ConfigureProcessConfigurationSecretNotFound:
-		return errors.New(p.Message.Value)
+		return NewError("UpdateSecret", errors.New(p.Message.Value))
 	case *v1.ConfigureProcessConfigurationSecretInternalServerError:
-		return errors.New(p.Message.Value)
+		return NewError("UpdateSecret", errors.New(p.Message.Value))
 	default:
-		return errors.New("unknown error")
+		return NewError("UpdateSecret", errors.New("unknown error"))
 	}
 }
 
 func (op *processConfigurationOp) Delete(ctx context.Context, id string) error {
 	res, err := op.client.DeleteProcessConfiguration(ctx, v1.DeleteProcessConfigurationParams{ID: id})
 	if err != nil {
-		return err
+		return NewError("Delete", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.DeleteProcessConfigurationOK:
 		return nil
 	case *v1.DeleteProcessConfigurationUnauthorized:
-		return errors.New(p.Message.Value)
+		return NewError("Delete", errors.New(p.Message.Value))
 	case *v1.DeleteProcessConfigurationBadRequest:
-		return errors.New(p.Message.Value)
+		return NewError("Delete", errors.New(p.Message.Value))
 	case *v1.DeleteProcessConfigurationNotFound:
-		return errors.New(p.Message.Value)
+		return NewError("Delete", errors.New(p.Message.Value))
 	case *v1.DeleteProcessConfigurationInternalServerError:
-		return errors.New(p.Message.Value)
+		return NewError("Delete", errors.New(p.Message.Value))
 	default:
-		return errors.New("unknown error")
+		return NewError("Delete", errors.New("unknown error"))
 	}
 }
 

--- a/schedules.go
+++ b/schedules.go
@@ -42,42 +42,42 @@ func NewScheduleOp(client *v1.Client) ScheduleAPI {
 func (op *scheduleOp) List(ctx context.Context) ([]v1.Schedule, error) {
 	res, err := op.client.GetSchedules(ctx)
 	if err != nil {
-		return nil, err
+		return nil, NewError("List", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.GetSchedulesOK:
 		return p.Schedules, nil
 	case *v1.GetSchedulesUnauthorized:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("List", errors.New(p.Message.Value))
 	case *v1.GetSchedulesBadRequest:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("List", errors.New(p.Message.Value))
 	case *v1.GetSchedulesInternalServerError:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("List", errors.New(p.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("List", errors.New("unknown error"))
 	}
 }
 
 func (op *scheduleOp) Read(ctx context.Context, id string) (*v1.Schedule, error) {
 	res, err := op.client.GetScheduleById(ctx, v1.GetScheduleByIdParams{ID: id})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Read", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.GetScheduleByIdOK:
 		return &p.Schedule, nil
 	case *v1.GetScheduleByIdUnauthorized:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Read", errors.New(p.Message.Value))
 	case *v1.GetScheduleByIdBadRequest:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Read", errors.New(p.Message.Value))
 	case *v1.GetScheduleByIdNotFound:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Read", errors.New(p.Message.Value))
 	case *v1.GetScheduleByIdInternalServerError:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Read", errors.New(p.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Read", errors.New("unknown error"))
 	}
 }
 
@@ -86,20 +86,20 @@ func (op *scheduleOp) Create(ctx context.Context, request v1.ScheduleRequestSett
 		Schedule: request,
 	})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Create", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.CreateScheduleOK:
 		return &p.Schedule, nil
 	case *v1.CreateScheduleBadRequest:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Create", errors.New(p.Message.Value))
 	case *v1.CreateScheduleUnauthorized:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Create", errors.New(p.Message.Value))
 	case *v1.CreateScheduleInternalServerError:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Create", errors.New(p.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Create", errors.New("unknown error"))
 	}
 }
 
@@ -108,41 +108,41 @@ func (op *scheduleOp) Update(ctx context.Context, id string, request v1.Schedule
 		Schedule: request,
 	}, v1.ConfigureScheduleParams{ID: id})
 	if err != nil {
-		return nil, err
+		return nil, NewError("Update", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.ConfigureScheduleOK:
 		return &p.Schedule, nil
 	case *v1.ConfigureScheduleBadRequest:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Update", errors.New(p.Message.Value))
 	case *v1.ConfigureScheduleNotFound:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Update", errors.New(p.Message.Value))
 	case *v1.ConfigureScheduleInternalServerError:
-		return nil, errors.New(p.Message.Value)
+		return nil, NewError("Update", errors.New(p.Message.Value))
 	default:
-		return nil, errors.New("unknown error")
+		return nil, NewError("Update", errors.New("unknown error"))
 	}
 }
 
 func (op *scheduleOp) Delete(ctx context.Context, id string) error {
 	res, err := op.client.DeleteSchedule(ctx, v1.DeleteScheduleParams{ID: id})
 	if err != nil {
-		return err
+		return NewError("Delete", err)
 	}
 
 	switch p := res.(type) {
 	case *v1.DeleteScheduleOK:
 		return nil
 	case *v1.DeleteScheduleUnauthorized:
-		return errors.New(p.Message.Value)
+		return NewError("Delete", errors.New(p.Message.Value))
 	case *v1.DeleteScheduleBadRequest:
-		return errors.New(p.Message.Value)
+		return NewError("Delete", errors.New(p.Message.Value))
 	case *v1.DeleteScheduleNotFound:
-		return errors.New(p.Message.Value)
+		return NewError("Delete", errors.New(p.Message.Value))
 	case *v1.DeleteScheduleInternalServerError:
-		return errors.New(p.Message.Value)
+		return NewError("Delete", errors.New(p.Message.Value))
 	default:
-		return errors.New("unknown error")
+		return NewError("Delete", errors.New("unknown error"))
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

通常のエラーを返すのではなくeventbus用のエラーを返すことでユーザが判別できるようにする。

### ドキュメントの変更は必要ですか？

必要なし