### PR TITLE
Use api-client-go's APIError

### DIFF
--- a/error.go
+++ b/error.go
@@ -14,6 +14,10 @@
 
 package eventbus
 
+import (
+	client "github.com/sacloud/api-client-go"
+)
+
 type Error struct {
 	msg string
 	err error
@@ -36,8 +40,9 @@ func (e *Error) Unwrap() error {
 }
 
 func NewError(msg string, err error) *Error {
-	if err == nil {
-		return &Error{msg: msg}
-	}
 	return &Error{msg: msg, err: err}
+}
+
+func NewAPIError(method string, code int, err error) *Error {
+	return &Error{msg: method, err: client.NewAPIError(code, "", err)}
 }

--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,8 @@ package eventbus
 import (
 	"errors"
 	"testing"
+
+	client "github.com/sacloud/api-client-go"
 )
 
 func TestError_Error(t *testing.T) {
@@ -51,5 +53,19 @@ func TestNewError(t *testing.T) {
 	err2 := NewError("msg only", nil)
 	if err2.msg != "msg only" || err2.err != nil {
 		t.Errorf("NewError() with nil err did not set fields correctly")
+	}
+}
+
+func TestNewAPIError(t *testing.T) {
+	baseErr := errors.New("base error")
+
+	err := NewAPIError("msg", 404, baseErr)
+	if !client.IsNotFoundError(err) {
+		t.Errorf("IsNotFoundError is true for NewAPIError with 404")
+	}
+
+	err2 := NewAPIError("msg", 503, nil)
+	if client.IsNotFoundError(err2) {
+		t.Errorf("IsNotFoundError is false for NewAPIError with 503")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.1.0
 	github.com/ogen-go/ogen v1.14.0
-	github.com/sacloud/api-client-go v0.3.0
+	github.com/sacloud/api-client-go v0.3.2
 	github.com/sacloud/packages-go v0.0.11
 	github.com/stretchr/testify v1.10.0
 )
@@ -29,7 +29,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/invopop/yaml v0.3.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
+github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/invopop/yaml v0.3.1 h1:f0+ZpmhfBSS4MhG+4HYseMdJhoeeopbSKbq5Rpeelso=
@@ -106,6 +108,10 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sacloud/api-client-go v0.3.0 h1:NLA2BpZ5welAXBPxgmXSCjgn/k0ShDB0x5kmUHl7TJ4=
 github.com/sacloud/api-client-go v0.3.0/go.mod h1:v8ke3pxVQ9TCWEbMkfbLX8NMeGiPpE+uDwlgcUWfMgM=
+github.com/sacloud/api-client-go v0.3.1 h1:1oUFXTCZ41kRur3I2ZFkYZE16dL/EY7SFnLVjCkCAlc=
+github.com/sacloud/api-client-go v0.3.1/go.mod h1:0p3ukcWYXRCc2AUWTl1aA+3sXLvurvvDqhRaLZRLBwo=
+github.com/sacloud/api-client-go v0.3.2 h1:INbdSpQbyGN9Ai4hQ+Gbv3UQcgtRPG2tJrOmqT7HGl0=
+github.com/sacloud/api-client-go v0.3.2/go.mod h1:0p3ukcWYXRCc2AUWTl1aA+3sXLvurvvDqhRaLZRLBwo=
 github.com/sacloud/go-http v0.1.9 h1:Xa5PY8/pb7XWhwG9nAeXSrYXPbtfBWqawgzxD5co3VE=
 github.com/sacloud/go-http v0.1.9/go.mod h1:DpDG+MSyxYaBwPJ7l3aKLMzwYdTVtC5Bo63HActcgoE=
 github.com/sacloud/packages-go v0.0.11 h1:hrRWLmfPM9w7GBs6xb5/ue6pEMl8t1UuDKyR/KfteHo=

--- a/process_configurations.go
+++ b/process_configurations.go
@@ -44,42 +44,42 @@ func NewProcessConfigurationOp(client *v1.Client) ProcessConfigurationAPI {
 func (op *processConfigurationOp) List(ctx context.Context) ([]v1.ProcessConfiguration, error) {
 	res, err := op.client.GetProcessConfigurations(ctx)
 	if err != nil {
-		return nil, NewError("List", err)
+		return nil, NewAPIError("ProcessConfiguration.List", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.GetProcessConfigurationsOK:
 		return p.ProcessConfigurations, nil
 	case *v1.GetProcessConfigurationsUnauthorized:
-		return nil, NewError("List", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.List", 401, errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationsBadRequest:
-		return nil, NewError("List", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.List", 400, errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationsInternalServerError:
-		return nil, NewError("List", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.List", 500, errors.New(p.Message.Value))
 	default:
-		return nil, NewError("List", errors.New("unknown error"))
+		return nil, NewAPIError("ProcessConfiguration.List", 0, nil)
 	}
 }
 
 func (op *processConfigurationOp) Read(ctx context.Context, id string) (*v1.ProcessConfiguration, error) {
 	res, err := op.client.GetProcessConfigurationById(ctx, v1.GetProcessConfigurationByIdParams{ID: id})
 	if err != nil {
-		return nil, NewError("Read", err)
+		return nil, NewAPIError("ProcessConfiguration.Read", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.GetProcessConfigurationByIdOK:
 		return &p.ProcessConfiguration, nil
 	case *v1.GetProcessConfigurationByIdUnauthorized:
-		return nil, NewError("Read", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Read", 401, errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationByIdBadRequest:
-		return nil, NewError("Read", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Read", 400, errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationByIdNotFound:
-		return nil, NewError("Read", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Read", 404, errors.New(p.Message.Value))
 	case *v1.GetProcessConfigurationByIdInternalServerError:
-		return nil, NewError("Read", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Read", 500, errors.New(p.Message.Value))
 	default:
-		return nil, NewError("Read", errors.New("unknown error"))
+		return nil, NewAPIError("ProcessConfiguration.Read", 0, nil)
 	}
 }
 
@@ -88,20 +88,20 @@ func (op *processConfigurationOp) Create(ctx context.Context, request v1.Process
 		ProcessConfiguration: request,
 	})
 	if err != nil {
-		return nil, NewError("Create", err)
+		return nil, NewAPIError("ProcessConfiguration.Create", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.CreateProcessConfigurationOK:
 		return &p.ProcessConfiguration, nil
 	case *v1.CreateProcessConfigurationBadRequest:
-		return nil, NewError("Create", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Create", 400, errors.New(p.Message.Value))
 	case *v1.CreateProcessConfigurationUnauthorized:
-		return nil, NewError("Create", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Create", 401, errors.New(p.Message.Value))
 	case *v1.CreateProcessConfigurationInternalServerError:
-		return nil, NewError("Create", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Create", 500, errors.New(p.Message.Value))
 	default:
-		return nil, NewError("Create", errors.New("unknown error"))
+		return nil, NewAPIError("ProcessConfiguration.Create", 0, nil)
 	}
 }
 
@@ -110,20 +110,20 @@ func (op *processConfigurationOp) Update(ctx context.Context, id string, request
 		ProcessConfiguration: request,
 	}, v1.ConfigureProcessConfigurationParams{ID: id})
 	if err != nil {
-		return nil, NewError("Update", err)
+		return nil, NewAPIError("ProcessConfiguration.Update", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.ConfigureProcessConfigurationOK:
 		return &p.ProcessConfiguration, nil
 	case *v1.ConfigureProcessConfigurationBadRequest:
-		return nil, NewError("Update", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Update", 400, errors.New(p.Message.Value))
 	case *v1.ConfigureProcessConfigurationNotFound:
-		return nil, NewError("Update", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Update", 404, errors.New(p.Message.Value))
 	case *v1.ConfigureProcessConfigurationInternalServerError:
-		return nil, NewError("Update", errors.New(p.Message.Value))
+		return nil, NewAPIError("ProcessConfiguration.Update", 500, errors.New(p.Message.Value))
 	default:
-		return nil, NewError("Update", errors.New("unknown error"))
+		return nil, NewAPIError("ProcessConfiguration.Update", 0, nil)
 	}
 }
 
@@ -132,42 +132,42 @@ func (op *processConfigurationOp) UpdateSecret(ctx context.Context, id string, s
 		Secret: secret,
 	}, v1.ConfigureProcessConfigurationSecretParams{ID: id})
 	if err != nil {
-		return NewError("UpdateSecret", err)
+		return NewAPIError("ProcessConfiguration.UpdateSecret", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.ConfigureProcessConfigurationSecretOK:
 		return nil
 	case *v1.ConfigureProcessConfigurationSecretBadRequest:
-		return NewError("UpdateSecret", errors.New(p.Message.Value))
+		return NewAPIError("ProcessConfiguration.UpdateSecret", 400, errors.New(p.Message.Value))
 	case *v1.ConfigureProcessConfigurationSecretNotFound:
-		return NewError("UpdateSecret", errors.New(p.Message.Value))
+		return NewAPIError("ProcessConfiguration.UpdateSecret", 404, errors.New(p.Message.Value))
 	case *v1.ConfigureProcessConfigurationSecretInternalServerError:
-		return NewError("UpdateSecret", errors.New(p.Message.Value))
+		return NewAPIError("ProcessConfiguration.UpdateSecret", 500, errors.New(p.Message.Value))
 	default:
-		return NewError("UpdateSecret", errors.New("unknown error"))
+		return NewAPIError("ProcessConfiguration.UpdateSecret", 0, nil)
 	}
 }
 
 func (op *processConfigurationOp) Delete(ctx context.Context, id string) error {
 	res, err := op.client.DeleteProcessConfiguration(ctx, v1.DeleteProcessConfigurationParams{ID: id})
 	if err != nil {
-		return NewError("Delete", err)
+		return NewAPIError("ProcessConfiguration.Delete", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.DeleteProcessConfigurationOK:
 		return nil
 	case *v1.DeleteProcessConfigurationUnauthorized:
-		return NewError("Delete", errors.New(p.Message.Value))
+		return NewAPIError("ProcessConfiguration.Delete", 401, errors.New(p.Message.Value))
 	case *v1.DeleteProcessConfigurationBadRequest:
-		return NewError("Delete", errors.New(p.Message.Value))
+		return NewAPIError("ProcessConfiguration.Delete", 400, errors.New(p.Message.Value))
 	case *v1.DeleteProcessConfigurationNotFound:
-		return NewError("Delete", errors.New(p.Message.Value))
+		return NewAPIError("ProcessConfiguration.Delete", 404, errors.New(p.Message.Value))
 	case *v1.DeleteProcessConfigurationInternalServerError:
-		return NewError("Delete", errors.New(p.Message.Value))
+		return NewAPIError("ProcessConfiguration.Delete", 500, errors.New(p.Message.Value))
 	default:
-		return NewError("Delete", errors.New("unknown error"))
+		return NewAPIError("ProcessConfiguration.Delete", 0, nil)
 	}
 }
 

--- a/schedules.go
+++ b/schedules.go
@@ -42,42 +42,42 @@ func NewScheduleOp(client *v1.Client) ScheduleAPI {
 func (op *scheduleOp) List(ctx context.Context) ([]v1.Schedule, error) {
 	res, err := op.client.GetSchedules(ctx)
 	if err != nil {
-		return nil, NewError("List", err)
+		return nil, NewAPIError("Schedule.List", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.GetSchedulesOK:
 		return p.Schedules, nil
 	case *v1.GetSchedulesUnauthorized:
-		return nil, NewError("List", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.List", 401, errors.New(p.Message.Value))
 	case *v1.GetSchedulesBadRequest:
-		return nil, NewError("List", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.List", 400, errors.New(p.Message.Value))
 	case *v1.GetSchedulesInternalServerError:
-		return nil, NewError("List", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.List", 500, errors.New(p.Message.Value))
 	default:
-		return nil, NewError("List", errors.New("unknown error"))
+		return nil, NewAPIError("Schedule.List", 0, nil)
 	}
 }
 
 func (op *scheduleOp) Read(ctx context.Context, id string) (*v1.Schedule, error) {
 	res, err := op.client.GetScheduleById(ctx, v1.GetScheduleByIdParams{ID: id})
 	if err != nil {
-		return nil, NewError("Read", err)
+		return nil, NewAPIError("Schedule.Read", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.GetScheduleByIdOK:
 		return &p.Schedule, nil
 	case *v1.GetScheduleByIdUnauthorized:
-		return nil, NewError("Read", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Read", 401, errors.New(p.Message.Value))
 	case *v1.GetScheduleByIdBadRequest:
-		return nil, NewError("Read", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Read", 400, errors.New(p.Message.Value))
 	case *v1.GetScheduleByIdNotFound:
-		return nil, NewError("Read", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Read", 404, errors.New(p.Message.Value))
 	case *v1.GetScheduleByIdInternalServerError:
-		return nil, NewError("Read", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Read", 500, errors.New(p.Message.Value))
 	default:
-		return nil, NewError("Read", errors.New("unknown error"))
+		return nil, NewAPIError("Schedule.Read", 0, nil)
 	}
 }
 
@@ -86,20 +86,20 @@ func (op *scheduleOp) Create(ctx context.Context, request v1.ScheduleRequestSett
 		Schedule: request,
 	})
 	if err != nil {
-		return nil, NewError("Create", err)
+		return nil, NewAPIError("Schedule.Create", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.CreateScheduleOK:
 		return &p.Schedule, nil
 	case *v1.CreateScheduleBadRequest:
-		return nil, NewError("Create", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Create", 400, errors.New(p.Message.Value))
 	case *v1.CreateScheduleUnauthorized:
-		return nil, NewError("Create", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Create", 401, errors.New(p.Message.Value))
 	case *v1.CreateScheduleInternalServerError:
-		return nil, NewError("Create", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Create", 500, errors.New(p.Message.Value))
 	default:
-		return nil, NewError("Create", errors.New("unknown error"))
+		return nil, NewAPIError("Schedule.Create", 0, nil)
 	}
 }
 
@@ -108,41 +108,41 @@ func (op *scheduleOp) Update(ctx context.Context, id string, request v1.Schedule
 		Schedule: request,
 	}, v1.ConfigureScheduleParams{ID: id})
 	if err != nil {
-		return nil, NewError("Update", err)
+		return nil, NewAPIError("Schedule.Update", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.ConfigureScheduleOK:
 		return &p.Schedule, nil
 	case *v1.ConfigureScheduleBadRequest:
-		return nil, NewError("Update", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Update", 400, errors.New(p.Message.Value))
 	case *v1.ConfigureScheduleNotFound:
-		return nil, NewError("Update", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Update", 404, errors.New(p.Message.Value))
 	case *v1.ConfigureScheduleInternalServerError:
-		return nil, NewError("Update", errors.New(p.Message.Value))
+		return nil, NewAPIError("Schedule.Update", 500, errors.New(p.Message.Value))
 	default:
-		return nil, NewError("Update", errors.New("unknown error"))
+		return nil, NewAPIError("Schedule.Update", 0, nil)
 	}
 }
 
 func (op *scheduleOp) Delete(ctx context.Context, id string) error {
 	res, err := op.client.DeleteSchedule(ctx, v1.DeleteScheduleParams{ID: id})
 	if err != nil {
-		return NewError("Delete", err)
+		return NewAPIError("Schedule.Delete", 0, err)
 	}
 
 	switch p := res.(type) {
 	case *v1.DeleteScheduleOK:
 		return nil
 	case *v1.DeleteScheduleUnauthorized:
-		return NewError("Delete", errors.New(p.Message.Value))
+		return NewAPIError("Schedule.Delete", 401, errors.New(p.Message.Value))
 	case *v1.DeleteScheduleBadRequest:
-		return NewError("Delete", errors.New(p.Message.Value))
+		return NewAPIError("Schedule.Delete", 400, errors.New(p.Message.Value))
 	case *v1.DeleteScheduleNotFound:
-		return NewError("Delete", errors.New(p.Message.Value))
+		return NewAPIError("Schedule.Delete", 404, errors.New(p.Message.Value))
 	case *v1.DeleteScheduleInternalServerError:
-		return NewError("Delete", errors.New(p.Message.Value))
+		return NewAPIError("Schedule.Delete", 500, errors.New(p.Message.Value))
 	default:
-		return NewError("Delete", errors.New("unknown error"))
+		return NewAPIError("Schedule.Delete", 0, nil)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

api-client-goに実装されたAPIErrorを使ってエラーを返すようにする。
丸められたエラーではなくステータスコード等も取得できるようになるので、それによって処理を分けられるようになる。

### ドキュメントの変更は必要ですか？

必要無し